### PR TITLE
bugfix: Onboarding make email case insensitive

### DIFF
--- a/app/src/main/java/simform/gitexcercise/android/ui/auth/login/LoginViewModel.kt
+++ b/app/src/main/java/simform/gitexcercise/android/ui/auth/login/LoginViewModel.kt
@@ -9,7 +9,7 @@ class LoginViewModel : ViewModel() {
     val loginDetail = MutableStateFlow(LoginDetail())
 
     fun validateDetails(): Boolean =
-        loginDetail.value.email == EMAIL && loginDetail.value.password == PASSWORD
+        loginDetail.value.email.equals(EMAIL, true) && loginDetail.value.password == PASSWORD
 
     companion object {
         private const val EMAIL = "test@simformsolutions.com"


### PR DESCRIPTION
- The email field was case-sensitive.
- fix: Make email validation case-insensitive.
- `test@simformsolutions.com` & `Test@SimformSolutions.com` both are valid email.